### PR TITLE
Replace updated MDToolbar:

### DIFF
--- a/firebaseloginscreen/signinscreen.kv
+++ b/firebaseloginscreen/signinscreen.kv
@@ -1,7 +1,6 @@
 <SignInScreen>:
     FloatLayout:
         MDTopAppBar:
-            title: "Sign In"
             md_bg_color: 0,0,0,0
             elevation: 0
             pos_hint: {"top": 1}

--- a/firebaseloginscreen/signinscreen.kv
+++ b/firebaseloginscreen/signinscreen.kv
@@ -1,6 +1,7 @@
 <SignInScreen>:
     FloatLayout:
-        MDToolbar:
+        MDTopAppBar:
+            title: "Sign In"
             md_bg_color: 0,0,0,0
             elevation: 0
             pos_hint: {"top": 1}

--- a/firebaseloginscreen/signupscreen.kv
+++ b/firebaseloginscreen/signupscreen.kv
@@ -1,7 +1,6 @@
 <SignUpScreen>:
     FloatLayout:
         MDTopAppBar:
-            title: "Sign Up"
             md_bg_color: 0,0,0,0
             elevation: 0
             pos_hint: {"top": 1}

--- a/firebaseloginscreen/signupscreen.kv
+++ b/firebaseloginscreen/signupscreen.kv
@@ -1,6 +1,7 @@
 <SignUpScreen>:
     FloatLayout:
-        MDToolbar:
+        MDTopAppBar:
+            title: "Sign Up"
             md_bg_color: 0,0,0,0
             elevation: 0
             pos_hint: {"top": 1}


### PR DESCRIPTION
It appears MDToolbar was made redundant and replaced with MDTopAppBar:

With current code the user gets ```kivy.factory.FactoryException: Unknown class <MDToolbar>``` errors

These changes prevent that and allows the code to run as expected as of Oct 2022. 